### PR TITLE
Handle error events on heartbeats

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,6 +67,9 @@ function start (callback) {
             server = app.listen(port, () => {
               if (apiConf.heartbeat) {
                 const configEmitter = medUtils.activateHeartbeat(apiConf.api)
+                configEmitter.on('error', (err) => {
+                  Winston.error('Heartbeat failed', err)
+                })
                 configEmitter.on('config', (newConfig) => {
                   Winston.info('Received updated config:', JSON.stringify(newConfig))
 


### PR DESCRIPTION
When sending heartbeats to the OpenHIM errors were being emitted but not
handled which resulted in the facility cache crashing. Heartbeats are
not critical to the cache so the errors can just be logged.